### PR TITLE
Replace ValidationError with SuspiciousOperation in views

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -262,6 +262,14 @@ class LoginTest(UserMixin, TestCase):
                                'login_view-current_step': 'auth'})
         self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
 
+    def test_missing_management_data(self):
+        # missing management data
+        response = self._post({'auth-username': 'bouke@example.com',
+                               'auth-password': 'secret'})
+
+        # view should return HTTP 400 Bad Request
+        self.assertEqual(response.status_code, 400)
+
 
 class BackupTokensTest(UserMixin, TestCase):
     def setUp(self):

--- a/tests/test_views_phone.py
+++ b/tests/test_views_phone.py
@@ -124,6 +124,14 @@ class PhoneSetupTest(UserMixin, TestCase):
         self.assertIn('cancel_url', context)
         self.assertEqual(url, context['cancel_url'])
 
+    def test_missing_management_data(self):
+        # missing management data
+        response = self._post({'setup-number': '123',
+                               'setup-method': 'call'})
+
+        # view should return HTTP 400 Bad Request
+        self.assertEqual(response.status_code, 400)
+
 
 class PhoneDeleteTest(UserMixin, TestCase):
     def setUp(self):

--- a/tests/test_views_setup.py
+++ b/tests/test_views_setup.py
@@ -228,3 +228,10 @@ class SetupTest(UserMixin, TestCase):
         with self.settings(TWO_FACTOR_SMS_GATEWAY='two_factor.gateways.fake.Fake'):
             response = self.client.get(reverse('two_factor:setup_complete'))
             self.assertContains(response, 'Add Phone Number')
+
+    def test_missing_management_data(self):
+        # missing management data
+        response = self._post({'validation-token': '666'})
+
+        # view should return HTTP 400 Bad Request
+        self.assertEqual(response.status_code, 400)

--- a/tests/test_yubikey.py
+++ b/tests/test_yubikey.py
@@ -115,3 +115,12 @@ class YubiKeyTest(UserMixin, TestCase):
                                     data={'wizard_goto_step': 'backup'})
         self.assertNotContains(response, 'YubiKey:')
         self.assertContains(response, 'Token:')
+
+    def test_missing_management_data(self):
+        # missing management data
+        response = self.client.post(reverse('two_factor:login'),
+                                    data={'auth-username': 'bouke@example.com',
+                                          'auth-password': 'secret'})
+
+        # view should return HTTP 400 Bad Request
+        self.assertEqual(response.status_code, 400)

--- a/two_factor/views/utils.py
+++ b/two_factor/views/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import SuspiciousOperation
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from formtools.wizard.forms import ManagementForm
@@ -108,10 +108,7 @@ class IdempotentSessionWizardView(SessionWizardView):
         # Check if form was refreshed
         management_form = ManagementForm(self.request.POST, prefix=self.prefix)
         if not management_form.is_valid():
-            raise ValidationError(
-                _('ManagementForm data is missing or has been tampered.'),
-                code='missing_management_form',
-            )
+            raise SuspiciousOperation(_('ManagementForm data is missing or has been tampered.'))
 
         form_current_step = management_form.cleaned_data['current_step']
         if (form_current_step != self.steps.current and


### PR DESCRIPTION
Nothing catches the ValidationError, causing a 500 error to be given.
SuspiciousOperation is caught by Django and a HTTP 400 response is
returned to the client.

Fixes #243

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
